### PR TITLE
Update ApiModule.py to fix CRITICAL - not well-formed (invalid token): line 27, column 30

### DIFF
--- a/NZBmegasearch/ApiModule.py
+++ b/NZBmegasearch/ApiModule.py
@@ -277,7 +277,7 @@ class ApiResponses:
 	def tvrage_getshowinfo(self, rid ):	
 		parsed_data = {'showtitle': ''}
 
-		url_tvrage = 'http://www.tvrage.com/feeds/showinfo.php'
+		url_tvrage = 'http://services.tvrage.com/feeds/showinfo.php'
 		urlParams = dict( sid=rid )			
 		#~ loading
 		try:


### PR DESCRIPTION
it seems sickbeard doesn't like nzbmegasearch atm #128 the API URL is wrong

source http://services.tvrage.com/info.php?page=main
