### PR TITLE
Create unique GUID URL's for NZBDrone compatibility

### DIFF
--- a/NZBmegasearch/ApiModule.py
+++ b/NZBmegasearch/ApiModule.py
@@ -30,6 +30,7 @@ import urllib2
 import os
 import logging
 import copy
+import uuid
 
 log = logging.getLogger(__name__)
 
@@ -426,7 +427,7 @@ class ApiResponses:
 
 				#~ non CP request generate might errors if no url is found in the permalink
 				if(self.typesearch != 0):
-					niceResults_row['encodedurl'] = 'http://bogus.gu/bog'
+					niceResults_row['encodedurl'] = self.rqurl + '/' + str(uuid.uuid4())
 					
 				niceResults.append(	niceResults_row)
 							

--- a/NZBmegasearch/SuggestionModule.py
+++ b/NZBmegasearch/SuggestionModule.py
@@ -236,7 +236,7 @@ class SuggestionResponses:
 #~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~
 	def get_show_lastepisode(self, rid):
 		parsed_data = []
-		url_tvrage = 'http://www.tvrage.com/feeds/episode_list.php'
+		url_tvrage = 'http://services.tvrage.com/feeds/episode_list.php'
 		urlParams = dict( sid=rid )			
 		#~ print urlParams
 		try:


### PR DESCRIPTION
As per http://forums.nzbdrone.com/t/2097 the Develop branch now identifies release by GUID. 

I barely know anything about python so this took some time to do but seems to work well. NZB MegasearcH by default just used a bogus URL for GUID, I've replaced it with a random UUID which should always be unique.

Results before change (Note line #9): https://pastebin.com/jGfdca9i

After: https://pastebin.com/G5q1jx48

This PR also fixes the TVRage suggestions module errors mentioned here: https://github.com/pillone/usntssearch/issues/137
